### PR TITLE
Add check that view exists for panel

### DIFF
--- a/SublimeQuickFileCreator.py
+++ b/SublimeQuickFileCreator.py
@@ -65,7 +65,7 @@ class QuickCreateFileCreatorBase(sublime_plugin.WindowCommand):
 
     def move_current_directory_to_top(self):
         view = self.window.active_view()
-        if view.file_name():
+        if view and view.file_name():
             cur_dir = os.path.dirname(view.file_name())[self.rel_path_start:]
             if cur_dir in self.full_torelative_paths:
                 i = self.relative_paths.index(cur_dir)


### PR DESCRIPTION
There was a bug that the `quick_panel` prompt would not open when:
- There is at least 1 non-top level directory in the project
- The panel you are running the shortcut from, does not have any views open

The error that was coming up was:

``` python
Traceback (most recent call last):
  File "./sublime_plugin.py", line 339, in run_
  File "./SublimeQuickFileCreator.py", line 108, in run
  File "./SublimeQuickFileCreator.py", line 20, in doCommand
  File "./SublimeQuickFileCreator.py", line 68, in move_current_directory_to_top
AttributeError: 'NoneType' object has no attribute 'file_name'
```

This pull request patches the bug as described above.
