### PR TITLE
Fix Windows relative path logic. Fixes #8

### DIFF
--- a/SublimeQuickFileCreator.py
+++ b/SublimeQuickFileCreator.py
@@ -7,7 +7,7 @@ import sublime_plugin
 class QuickCreateFileCreatorBase(sublime_plugin.WindowCommand):
     relative_paths = []
     full_torelative_paths = {}
-    rel_path_start = 0
+    rel_path_start = ''
 
     def doCommand(self):
         self.construct_excluded_pattern()
@@ -51,14 +51,15 @@ class QuickCreateFileCreatorBase(sublime_plugin.WindowCommand):
         self.full_torelative_paths = {}
         for path in folders:
             rootfolders = os.path.split(path)[-1]
-            self.rel_path_start = len(os.path.split(path)[0]) + 1
+            self.rel_path_start = os.path.split(path)[0]
             if not self.excluded.search(rootfolders):
                 self.full_torelative_paths[rootfolders] = path
                 self.relative_paths.append(rootfolders)
 
+
             for base, dirs, files in os.walk(path):
                 for dir in dirs:
-                    relative_path = os.path.join(base, dir)[self.rel_path_start:]
+                    relative_path = os.path.relpath(os.path.join(base, dir), self.rel_path_start)
                     if not self.excluded.search(relative_path):
                         self.full_torelative_paths[relative_path] = os.path.join(base, dir)
                         self.relative_paths.append(relative_path)
@@ -66,7 +67,7 @@ class QuickCreateFileCreatorBase(sublime_plugin.WindowCommand):
     def move_current_directory_to_top(self):
         view = self.window.active_view()
         if view and view.file_name():
-            cur_dir = os.path.dirname(view.file_name())[self.rel_path_start:]
+            cur_dir = os.path.relpath(os.path.dirname(view.file_name()), self.rel_path_start)
             if cur_dir in self.full_torelative_paths:
                 i = self.relative_paths.index(cur_dir)
                 self.relative_paths.insert(0, self.relative_paths.pop(i))


### PR DESCRIPTION
As discovered in #8, we have path issues on Windows. The source of the issue is the number-based slicing is running into issues with escaped characters on Windows (e.g. `F:\\`). To resolve this, we are moving away from numbers and onto string replacement.

In this PR:
- Replaced number based slicing with string replacement
  - Store `rel_path_start` as the string we were previously computing the length of
  - Use `os.path.relpath` to replace relative path base 

Tested in Sublime Text 3 on Windows and Sublime Text 2 on Linux

/cc @noklesta
