### PR TITLE
Prevent os.walk() from recurring into excluded directories

### DIFF
--- a/SublimeQuickFileCreator.py
+++ b/SublimeQuickFileCreator.py
@@ -46,7 +46,6 @@ class QuickCreateFileCreatorBase(sublime_plugin.WindowCommand):
 
     def build_relative_paths(self):
         folders = self.window.folders()
-        view = self.window.active_view()
         self.relative_paths = []
         self.full_torelative_paths = {}
         for path in folders:

--- a/SublimeQuickFileCreator.py
+++ b/SublimeQuickFileCreator.py
@@ -62,6 +62,8 @@ class QuickCreateFileCreatorBase(sublime_plugin.WindowCommand):
                     if not self.excluded.search(relative_path):
                         self.full_torelative_paths[relative_path] = os.path.join(base, dir)
                         self.relative_paths.append(relative_path)
+                    else:
+                        dirs.remove(dir)
 
     def move_current_directory_to_top(self):
         view = self.window.active_view()


### PR DESCRIPTION
So there was this issue that while excluding directories hides them from the selection panel, they were still traversed. Which mostly defeated the purpose of excluding them in the first place.

This modification removes the excluded directories from the traversal tree. Now excluding directories actually improves performance.

Fixes #5 

Tested in ST2 and ST3.